### PR TITLE
Remove Google Analytics

### DIFF
--- a/modules/sections/_foot.hbs
+++ b/modules/sections/_foot.hbs
@@ -8,11 +8,5 @@
   <script src="js/scripts.js?1"></script>
 {{/if}}
 
-<script>
-  window.ga=function(){ga.q.push(arguments)};ga.q=[];ga.l=+new Date;
-  ga('create','UA-592624-3','auto');ga('send','pageview')
-</script>
-<script src="https://www.google-analytics.com/analytics.js" async defer></script>
-
 </body>
 </html>


### PR DESCRIPTION
Would you be willing to remove this Google Analytics 'functionality' from this website? There are better alternatives if you _must_ keep tabs on users' activity.

Some reputable alternatives can be seen here: https://switching.software/replace/google-analytics/